### PR TITLE
Add PHP 8.1 test on GitHub workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PhpToken Polyfill
+# array_key_first_last Polyfill
 
 A polyfill to bring the [PHP 7.3 `array_key_first`](https://www.php.net/manual/en/function.array-key-first.php) and [PHP 7.3 `array_key_last`](https://www.php.net/manual/en/function.array-key-last.php) functions to PHP 5.3 and later.
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A simple polyfill to make PHP 7.3's array_key_first and array_key_last functions available to all.",
     "type": "library",
     "require": {
-        "php": "^5.3 || ^7.0"
+        "php": "^5.3 || ^7.0 || ^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0 || ^8.0 || ^9.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         forceCoversAnnotation="true"
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"


### PR DESCRIPTION
# Changed log

- Add `php-8.1` version test in GitHub workflows.
- Change into `array_key_first_last` title.
- Add the `^8.0` inside `require` block in `composer.json` file.
- Remove the `forceCoversAnnotation` attribute setting in `phpunit.xml.dist` file to avoid `@covers` annotation checking forcedably.